### PR TITLE
01: solana rust program with processor method stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,31 @@ It is built using the _MetaStack_ consisting of the following tools:
 - [amman](https://github.com/metaplex-foundation/amman) which allows debugging and testing the
   program on a local validator
 
+## Workshop
+
+This workshop is implemented via pull requests. Each pull request adds a tool or feature and
+explains how this was done and how you as a developer can experiment with the contract at the
+current stage.
+
+In most cases this involves building the Rust program, updating the SDK and running some
+functions against that program after it is deployed on a local validator via _amman_.
+
+### Prerequisites
+
+- [install solana](https://docs.solana.com/cli/install-solana-cli-tools) in order to make a
+  local validator available on your machine as well as gain access to commands like 
+  `cargo build-bpf`
+
+### Building the Rust Program
+
+```sh
+cd program && cargo build-bpf
+```
+
+## Steps
+
+1. [adding solana rust program with processor method stubs](https://github.com/thlorenz/tictactoe/pull/1)
+
 ## Resources
 
 - [Figma

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "tictactoe"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "tictactoe"
+doctest = false
+
+[features]
+no-entrypoint = []
+cpi = ["no-entrypoint"]
+test-bpf = []
+
+[dependencies]
+borsh = "0.9.3"
+num-derive = "0.3.3"
+num-traits = "0.2.15"
+solana-program = "1.14.5"
+thiserror = "1.0.37"

--- a/program/Xargo.toml
+++ b/program/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/program/rustfmt.toml
+++ b/program/rustfmt.toml
@@ -1,0 +1,9 @@
+edition = "2021"
+max_width = 80
+imports_indent = "Block"
+imports_layout = "Mixed"
+imports_granularity = "Crate"
+group_imports = "Preserve"
+reorder_imports = true
+reorder_modules = true
+reorder_impl_items = false

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -1,0 +1,21 @@
+use solana_program::{
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
+    program_error::PrintProgramError, pubkey::Pubkey,
+};
+
+use crate::{processor, TictactoeError};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    if let Err(error) =
+        processor::process(program_id, accounts, instruction_data)
+    {
+        error.print::<TictactoeError>();
+        return Err(error);
+    }
+    Ok(())
+}

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -1,0 +1,34 @@
+use num_derive::FromPrimitive;
+use solana_program::{
+    decode_error::DecodeError,
+    msg,
+    program_error::{PrintProgramError, ProgramError},
+};
+use thiserror::Error;
+
+#[derive(Clone, Debug, Eq, Error, PartialEq, FromPrimitive)]
+pub enum TictactoeError {
+    #[error("You are not authorized to perform this action.")]
+    Unauthorized = 0x71c7ac,
+}
+
+// -----------------
+// Trait Impls
+// -----------------
+impl PrintProgramError for TictactoeError {
+    fn print<E>(&self) {
+        msg!(&self.to_string());
+    }
+}
+
+impl From<TictactoeError> for ProgramError {
+    fn from(e: TictactoeError) -> Self {
+        ProgramError::Custom(e as u32)
+    }
+}
+
+impl<T> DecodeError<T> for TictactoeError {
+    fn type_of() -> &'static str {
+        "Tictactoe Error"
+    }
+}

--- a/program/src/instructions.rs
+++ b/program/src/instructions.rs
@@ -1,0 +1,20 @@
+use borsh::BorshDeserialize;
+
+// -----------------
+// Instruction
+// -----------------
+#[derive(BorshDeserialize)]
+pub enum TictactoeInstruction {
+    InitializeGame,
+    PlayerJoin,
+    PlayerMove(PlayerMove),
+}
+
+// -----------------
+// Player Move
+// -----------------
+#[derive(BorshDeserialize)]
+pub struct PlayerMove {
+    pub x_or_o: u8,
+    pub field: u8,
+}

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,14 +1,11 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+use solana_program::declare_id;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+mod entrypoint;
+mod error;
+mod instructions;
+mod processor;
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub use error::*;
+pub use instructions::*;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1,0 +1,39 @@
+use borsh::BorshDeserialize;
+use solana_program::{
+    account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey,
+};
+
+use crate::{PlayerMove, TictactoeInstruction};
+
+pub fn process(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    let instruction = TictactoeInstruction::try_from_slice(instruction_data)?;
+
+    use TictactoeInstruction::*;
+    match instruction {
+        InitializeGame => initialize_game(accounts),
+        PlayerJoin => player_join(accounts),
+        PlayerMove(args) => player_move(accounts, args),
+    }
+}
+
+pub fn initialize_game(accounts: &[AccountInfo]) -> ProgramResult {
+    msg!("IX: initialize_game, passed {} accounts", accounts.len());
+    Ok(())
+}
+
+pub fn player_join(accounts: &[AccountInfo]) -> ProgramResult {
+    msg!("IX: player_join, passed {} accounts", accounts.len());
+    Ok(())
+}
+
+pub fn player_move(
+    accounts: &[AccountInfo],
+    _player_move: PlayerMove,
+) -> ProgramResult {
+    msg!("IX: player_move, passed {} accounts", accounts.len());
+    Ok(())
+}


### PR DESCRIPTION
[~previous~]()  |  [next](https://github.com/thlorenz/tictactoe/pull/2)

* * *

# Summary

In this PR we add the pure Rust solana program with the following instructions that our game
will eventually handle.

- **InitializeGame**: will initialize a new TicTacToe and add the player who initialized it
- **PlayerJoin**: will allow the second player to join the game
- **PlayerMove**: will allow each player to make a move in the game

## What you should do

Read through the [changed files](https://github.com/thlorenz/tictactoe/pull/1/files) in this PR
and try to understand the changes here.

Five main files were added:

- **entrypoint.rs**: the entry point to the program when it is deployed on chain
- **error.rs**: the list of errors that the program may raise in the future
- **instructions.rs**: the enum of _instructions_ that the program supports
- **processor.rs**: contains the methods that process each instruction
- **lib.rs**: provides access to all the above modules

You don't have to understand each detail, but try to get a general idea of what is going on in
each module.

## What you can do with it

After checking out this branch (which you can do in your local environment via `git switch 01 -c pr/01`), you can build the `.so` file using `cargo build-bpf`. 
We will later use _amman_ in order to deploy it on the local validator and interact with it.

You could add some simple tests using the
[solana-test-crate](https://docs.rs/solana-program-test/1.14.5/solana_program_test/) however we
will debug and test our game using a TypeScript SDK which we will add in the next step.

* * *

[~previous~]()  |  [next](https://github.com/thlorenz/tictactoe/pull/2)
