### PR TITLE
05: setup amman and added initialize game test

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ For example to checkout step **2** you'd do: `git switch 2 -c pr/2`.
 2. [setup SDK package](https://github.com/thlorenz/tictactoe/pull/2)
 3. [preparing SDK generation](https://github.com/thlorenz/tictactoe/pull/3)
 4. [generating IDL and TypeScript SDK](https://github.com/thlorenz/tictactoe/pull/4)
+5. [setup amman and add initialize game test](https://github.com/thlorenz/tictactoe/pull/5)
 
 ## Resources
 

--- a/ts/.ammanrc.js
+++ b/ts/.ammanrc.js
@@ -1,0 +1,32 @@
+// @ts-check
+'use strict'
+const path = require('path')
+const { LOCALHOST, tmpLedgerDir } = require('@metaplex-foundation/amman')
+const PROGRAM_ID = require('./idl/tictactoe.json').metadata.address
+
+const localDeployPath = path.join(
+  __dirname,
+  '..',
+  'program',
+  'target',
+  'deploy'
+)
+
+module.exports = {
+  validator: {
+    killRunningValidators: true,
+    programs: [
+      {
+        label: 'TicTacToe Program',
+        programId: PROGRAM_ID,
+        deployPath: path.join(localDeployPath, 'tictactoe.so'),
+      },
+    ],
+    jsonRpcUrl: LOCALHOST,
+    ledgerDir: tmpLedgerDir(),
+    resetLedger: true,
+  },
+  storage: {
+    enabled: false,
+  },
+}

--- a/ts/package.json
+++ b/ts/package.json
@@ -12,6 +12,8 @@
     "pretest": "yarn build",
     "test": "tape dist/test/*.js",
     "t": "esr ./test/tictactoe.ts | tap-spec",
+    "amman:start": "DEBUG='amman:(info|error)' amman start",
+    "amman:stop": "amman stop",
     "api:gen": "solita"
   },
   "dependencies": {

--- a/ts/src/common/helpers.ts
+++ b/ts/src/common/helpers.ts
@@ -1,0 +1,10 @@
+import { PublicKey } from '@solana/web3.js'
+import { PROGRAM_ID } from '../tictactoe'
+
+export async function pdaForGame(game: PublicKey): Promise<PublicKey> {
+  const [pda] = await PublicKey.findProgramAddress(
+    [Buffer.from('tictactoe'), game.toBuffer()],
+    PROGRAM_ID
+  )
+  return pda
+}

--- a/ts/src/tictactoe.ts
+++ b/ts/src/tictactoe.ts
@@ -1,1 +1,2 @@
-export const TODO = "add some real code here";
+export * from './generated'
+export * from './common/helpers'

--- a/ts/test/tictactoe.ts
+++ b/ts/test/tictactoe.ts
@@ -8,11 +8,14 @@ import { amman, killStuckProcess } from './utils'
 killStuckProcess()
 
 async function setupPlayerX() {
+  // 1. Create a connection to the local test validator
   const connection = new Connection(LOCALHOST, 'confirmed')
 
+  // 2. Generate a keypair for the first player and have amman label it for us
   const [playerX, playerXPair] = await amman.addr.genLabeledKeypair('player x')
   await amman.airdrop(connection, playerX, 2)
 
+  // 3. Create a transaction handler that will use the first player as signer
   const transactionHandler = amman.payerTransactionHandler(
     connection,
     playerXPair
@@ -27,10 +30,13 @@ async function setupPlayerX() {
 }
 
 test('tx: init game and add player x', async (t) => {
+  // 1. Setup the player and its transaction handler
   const { playerXHandler, playerX, playerXPair } = await setupPlayerX()
 
+  // 2. Generate public key for our game and derive the game PDA
   const [game] = amman.addr.genKeypair()
   const gamePda = await pdaForGame(game)
+  // 3. Label the game PDA so we can identify it in the Amman Explorer
   await amman.addr.addLabels({ gamePda })
 
   const ix = createInitializeGameInstruction({

--- a/ts/test/tictactoe.ts
+++ b/ts/test/tictactoe.ts
@@ -1,5 +1,45 @@
+import { LOCALHOST } from '@metaplex-foundation/amman-client'
+import { Connection, Transaction } from '@solana/web3.js'
+import { createInitializeGameInstruction } from 'src/generated'
+import { pdaForGame } from 'src/tictactoe'
 import test from 'tape'
+import { amman, killStuckProcess } from './utils'
 
-test('todo: add real tests', (t) => {
-  t.end()  
+killStuckProcess()
+
+async function setupPlayerX() {
+  const connection = new Connection(LOCALHOST, 'confirmed')
+
+  const [playerX, playerXPair] = await amman.addr.genLabeledKeypair('player x')
+  await amman.airdrop(connection, playerX, 2)
+
+  const transactionHandler = amman.payerTransactionHandler(
+    connection,
+    playerXPair
+  )
+
+  return {
+    playerXHandler: transactionHandler,
+    connection,
+    playerX,
+    playerXPair,
+  }
+}
+
+test('tx: init game and add player x', async (t) => {
+  const { playerXHandler, playerX, playerXPair } = await setupPlayerX()
+
+  const [game] = amman.addr.genKeypair()
+  const gamePda = await pdaForGame(game)
+  await amman.addr.addLabels({ gamePda })
+
+  const ix = createInitializeGameInstruction({
+    playerX,
+    gamePda,
+  })
+
+  const tx = new Transaction().add(ix)
+  await playerXHandler
+    .sendAndConfirmTransaction(tx, [playerXPair], 'tx: init game')
+    .assertSuccess(t, [/IX: initialize_game/])
 })

--- a/ts/test/utils/amman.ts
+++ b/ts/test/utils/amman.ts
@@ -1,0 +1,7 @@
+import { Amman } from '@metaplex-foundation/amman-client'
+
+import { PROGRAM_ADDRESS } from '../../src/tictactoe'
+
+export const amman = Amman.instance({
+  knownLabels: { [PROGRAM_ADDRESS]: 'TicTacToe' },
+})

--- a/ts/test/utils/index.ts
+++ b/ts/test/utils/index.ts
@@ -1,0 +1,7 @@
+import test from 'tape'
+
+export * from './amman'
+
+export function killStuckProcess() {
+  test.onFinish(() => process.exit(0))
+}

--- a/ts/test/utils/index.ts
+++ b/ts/test/utils/index.ts
@@ -2,6 +2,9 @@ import test from 'tape'
 
 export * from './amman'
 
+// Due to the web3.js Connection keeping a socket open our process
+// can get stuck for a few seconds.
+// Here we force the process to exit quickly when tests are done.
 export function killStuckProcess() {
   test.onFinish(() => process.exit(0))
 }


### PR DESCRIPTION
[previous](https://github.com/thlorenz/tictactoe/pull/4) |  [next](https://github.com/thlorenz/tictactoe/pull/6)

* * *

# Summary

In this PR we setup _amman_ to run our program in a local test validator and we added a test
that interacts with it by invoking the _initialize game_ instruction.

## Amman Config

Most options set in the `.ammanrc.js` default to reasonable values, so let's go over the ones
you're most likely going to change for your case.

_Amman_ reads this config and adjusts the way it provisions the local test validator, relay and
more to this configuration.

```js
const PROGRAM_ID = require('./idl/tictactoe.json').metadata.address
{
  // [..]
  validator: {
    programs: [
      {
        label: 'TicTacToe Program',
        programId: PROGRAM_ID,
        deployPath: path.join(localDeployPath, 'tictactoe.so'),
      },
    ],
  }
  // [..]
}
```

Here we define the program that we will deploy under the `PROGRAM_ID` loading it from the
provided `deployPath`.

```js
{
  // [..]
  storage: {
    enabled: false,
  },
  // [..]
}
}
```

Here we instruct _amman- that we won't be using mock storage since we're not uploading any
NFTs.

## Startup Amman

From inside the `./ts` folder run `yarn amman:start`.

_Amman_ will log information to the terminal regarding the startup. Keep this terminal open as
_amman_ will log data about executed transactions here as well once we run our tests.

<img width="839" alt="Screen Shot 2022-10-19 at 9 15 07 PM" src="https://user-images.githubusercontent.com/192891/196848048-137dfab6-efcc-4364-b2f2-b7e6c18da63c.png">

## Amman Explorer

Head over to [amman-explorer](https://amman-explorer.metaplex.com/) and refresh it to have it
sync with amman.

You should see the following:
<img width="941" alt="Screen Shot 2022-10-19 at 9 16 05 PM" src="https://user-images.githubusercontent.com/192891/196848173-3504786c-b2c2-41cc-b5d4-d39af894ea99.png">
_NOTE_ that at this point it is not showing any _Recent Transactions_ ... yet.

## Running your Tests

Run `yarn t` from inside the `./ts` folder and you should see the following.
<img width="1058" alt="Screen Shot 2022-10-19 at 9 18 22 PM" src="https://user-images.githubusercontent.com/192891/196848421-60a27409-329c-428f-81a1-153b937450b5.png">
The top terminal shows the logs _amman_ prints and the bottom terminal shows the test output.

Use the Amman Explorer to diagnose the transactions that the tests executed and then come back here to have a closer look at the code.

<img width="941" alt="Screen Shot 2022-10-19 at 9 18 52 PM" src="https://user-images.githubusercontent.com/192891/196848494-77280f32-0811-45b0-94e3-2cbe7e1824da.png">
<img width="1139" alt="Screen Shot 2022-10-19 at 9 20 15 PM" src="https://user-images.githubusercontent.com/192891/196848625-53479d17-e438-4230-97fd-e00beac9b0ee.png">

## Tests and How they Interact with Amman

Have a look at `./test/utils/amman.ts` to see how simple it is to setup an _amman_ instance
that we use to talk to the _amman_ and test validator.

The tests inside `./tests/tictactoe.ts` were updated to setup the first player, the game pda and
then execute the transaction to initialize the TicTacToe game.

I recommend you to read through that code and particularly pay attention to how it interacts
with _amman_, i.e. to label account addresses.

When you send a transaction via the _amman_ transaction handler, it turns off `preflight`
checks in order to ensure that faulty transactions still run in the validator and are available
for inspection inside the Amman Explorer. 

For that reason it also requires you to assert that the transaction succeeded (or failed):

```ts
await playerXHandler
  .sendAndConfirmTransaction(tx, [playerXPair], 'tx: init game')
  .assertSuccess(t, [/IX: initialize_game/])
```

Omitting `.assertSuccess(..)` here will cause _amman_ to raise an error since it cannot be sure
that you're verifying the transaction otherwise.

* * *

[previous](https://github.com/thlorenz/tictactoe/pull/4) |  [next](https://github.com/thlorenz/tictactoe/pull/6)


