### PR TITLE
08: amman account providers and renderers

### DIFF
--- a/ts/.ammanrc.js
+++ b/ts/.ammanrc.js
@@ -3,6 +3,7 @@
 const path = require('path')
 const { LOCALHOST, tmpLedgerDir } = require('@metaplex-foundation/amman')
 const PROGRAM_ID = require('./idl/tictactoe.json').metadata.address
+const { accountProviders } = require('./dist/src/generated/accounts')
 
 const localDeployPath = path.join(
   __dirname,
@@ -25,6 +26,9 @@ module.exports = {
     jsonRpcUrl: LOCALHOST,
     ledgerDir: tmpLedgerDir(),
     resetLedger: true,
+  },
+  relay: {
+    accountProviders,
   },
   storage: {
     enabled: false,

--- a/ts/.ammanrc.js
+++ b/ts/.ammanrc.js
@@ -3,7 +3,7 @@
 const path = require('path')
 const { LOCALHOST, tmpLedgerDir } = require('@metaplex-foundation/amman')
 const PROGRAM_ID = require('./idl/tictactoe.json').metadata.address
-const { accountProviders } = require('./dist/src/generated/accounts')
+const { accountProviders, accountRenderers } = require('./dist/src/providers')
 
 const localDeployPath = path.join(
   __dirname,
@@ -29,6 +29,7 @@ module.exports = {
   },
   relay: {
     accountProviders,
+    accountRenderers,
   },
   storage: {
     enabled: false,

--- a/ts/src/providers.ts
+++ b/ts/src/providers.ts
@@ -1,0 +1,37 @@
+import { AmmanAccountRendererMap } from '@metaplex-foundation/amman-client'
+import { Game } from './generated'
+
+export * as accountProviders from './generated/accounts'
+
+const BOARD_ITEM_FREE = 0
+const BOARD_ITEM_X = 1
+const BOARD_ITEM_O = 2
+
+export const accountRenderers: AmmanAccountRendererMap = new Map([
+  [Game, renderGame],
+])
+
+export function renderGame(game: Game) {
+  const { board } = game
+  const i = board.map(renderBoardItem)
+  return `+---+---+---+
+|${i[0]}|${i[1]}|${i[2]}|
++---+---+---+
+|${i[3]}|${i[4]}|${i[5]}|
++---+---+---+
+|${i[6]}|${i[7]}|${i[8]}|
++---+---+---+`
+}
+
+function renderBoardItem(item: number) {
+  switch (item) {
+    case BOARD_ITEM_FREE:
+      return '   '
+    case BOARD_ITEM_X:
+      return ' X '
+    case BOARD_ITEM_O:
+      return ' O '
+    default:
+      throw new Error(`Unknown board item: ${item}`)
+  }
+}


### PR DESCRIPTION
[previous](https://github.com/thlorenz/tictactoe/pull/7) |  [next](https://github.com/thlorenz/tictactoe/pull/9)

* * *

# Summary

In this PR we add _account providers_ which allow the [amman-explorer](https://amman-explorer.metaplex.com/) to show more information which is especially useful for diagnostics.

## Account Providers

_Account Providers_ know how to deserialize account data and by linking them into the relay via
the _amman_ config we enable the _amman explorer_ to show data inside them.

Since these account providers are part of the generated code, we can simply re-export them to
make them available. We do so from our added `provider.ts` module.

```ts
export * as accountProviders from './generated/accounts'
```

This suffices to then include them in the `.ammanrc.js`.

```js
const { accountProviders } = require('./dist/src/providers')
// [ .. ]

module.exports = {
  // [ .. ]
  relay: {
    accountProviders,
  },
}
```

Let's rebuild our TypeScript (`yarn build`) and restart _amman_ (`yarn amman:start`).

Then run our test `yarn t` and can investigate the `gamePda` account by clicking it in the transaction output. It is the second account input.

<img width="1156" alt="Screen Shot 2022-10-20 at 3 50 05 PM" src="https://user-images.githubusercontent.com/192891/197071682-8b1eb023-bc42-46eb-b35d-81dcce9a8e6e.png">

If we then select the _Resolved Info_ tab we can confirm the following:

- `playerX` was set to the public key we provided
- `playerO` is still set to the default public key
- the game is waiting for the opponent
- once the opponent arrives _playerX_ is to move

<img width="1157" alt="Screen Shot 2022-10-20 at 3 50 34 PM" src="https://user-images.githubusercontent.com/192891/197071694-206e431c-b41a-4cb3-879f-3ed274d2b0ac.png">

However since the board is represented as a flat array it would be hard to investigate winning
conditions and such. We can improve on that by providing _amman_ with a function that _renders_
the game state

In our case rendering the board is all we need.

You can see the simple
[`renderGame`](https://github.com/thlorenz/tictactoe/pull/8/files#diff-1ddb3a507abe00c31b71aac6d1de6bff3aea1a1a391480121a046728072853d7R14) function we added to the `src/providers.ts`. It returns a
string representing the current board state.

We then register it with in the _amman_ config as follows.

```js
const { accountProviders, accountRenderers } = require('./dist/src/providers')
// [ .. ]

module.exports = {
  // [ .. ]
  relay: {
    accountProviders,
    accountRenderers,
  },
}
```

Now we can have a look at the `gamePda` again - this time we find it quicker via a search query
..

<img width="455" alt="Screen Shot 2022-10-20 at 4 06 20 PM" src="https://user-images.githubusercontent.com/192891/197071710-8b6242d4-d229-4323-ad54-a9e2c9f96e36.png">

and voilá we can see that our board is rendered at the bottom of the _Resolved Info_.

<img width="1149" alt="Screen Shot 2022-10-20 at 4 17 45 PM" src="https://user-images.githubusercontent.com/192891/197071731-dda47228-3a2a-4bb3-80a0-1d9bb3b64274.png">

## What you Can Do

Modify the render function to your liking and enjoy it in the explorer.

Remember to perform the following each time after a change:

- `yarn build`
- `yarn amman:start` -> refresh the amman explorer
- `yarn t`

* * *

[previous](https://github.com/thlorenz/tictactoe/pull/7) |  [next](https://github.com/thlorenz/tictactoe/pull/9)