### PR TITLE
09: implement join player instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ For example to checkout step **2** you'd do: `git switch 2 -c pr/2`.
 5. [setup amman and added initialize game test](https://github.com/thlorenz/tictactoe/pull/5)
 6. [fix build](https://github.com/thlorenz/tictactoe/pull/6) (_you may skip that one_)
 7. [add init game functionality](https://github.com/thlorenz/tictactoe/pull/7)
-8. [amman account providers and renderers ](https://github.com/thlorenz/tictactoe/pull/8)
+8. [amman account providers and renderers](https://github.com/thlorenz/tictactoe/pull/8)
+9. [implement join player instruction](https://github.com/thlorenz/tictactoe/pull/9)
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -53,14 +53,6 @@ cd ts && yarn test
 
 ## Steps
 
-**NOTE**: 
-
-Each step/pull-request is tagged and thus you can check them out via:
-
-`git switch <step> -c pr/<step>`.
-
-For example to checkout step **2** you'd do: `git switch 2 -c pr/2`.
-
 1. [adding solana rust program with processor method stubs](https://github.com/thlorenz/tictactoe/pull/1)
 2. [setup SDK package](https://github.com/thlorenz/tictactoe/pull/2)
 3. [preparing SDK generation](https://github.com/thlorenz/tictactoe/pull/3)
@@ -70,6 +62,14 @@ For example to checkout step **2** you'd do: `git switch 2 -c pr/2`.
 7. [add init game functionality](https://github.com/thlorenz/tictactoe/pull/7)
 8. [amman account providers and renderers](https://github.com/thlorenz/tictactoe/pull/8)
 9. [implement join player instruction](https://github.com/thlorenz/tictactoe/pull/9)
+
+**NOTE**: 
+
+Each step/pull-request is tagged and thus you can check them out via:
+
+`git switch <step> -c pr/<step>`.
+
+For example to checkout step **2** you'd do: `git switch 2 -c pr/2`.
 
 ## Resources
 

--- a/program/src/asserts.rs
+++ b/program/src/asserts.rs
@@ -1,8 +1,8 @@
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey,
+    account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey,
 };
 
-use crate::TictactoeError;
+use crate::{Game, GameState, TictactoeError};
 
 pub fn assert_signer(account: &AccountInfo) -> ProgramResult {
     if !account.is_signer {
@@ -18,6 +18,18 @@ pub fn assert_game_key_matches_account(
 ) -> ProgramResult {
     if game_key != game_account.key {
         Err(TictactoeError::InvalidGameAccount.into())
+    } else {
+        Ok(())
+    }
+}
+
+pub fn assert_waiting_for_opponent(game: &Game) -> ProgramResult {
+    if game.state != GameState::WaitingForOpponent {
+        msg!(&format!(
+            "Game state is {:?}, but should be waiting for opponent",
+            game.state
+        ));
+        Err(TictactoeError::ShouldBeWaitingForOpponent.into())
     } else {
         Ok(())
     }

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -19,6 +19,9 @@ pub enum TictactoeError {
 
     #[error("Game account specified is invalid.")]
     InvalidGameAccount,
+
+    #[error("Game should be waiting for opponent")]
+    ShouldBeWaitingForOpponent,
 }
 
 // -----------------

--- a/program/src/instructions.rs
+++ b/program/src/instructions.rs
@@ -12,7 +12,11 @@ pub enum TictactoeInstruction {
     #[account(name = "game_pda", mut, desc="The game PDA")]
     #[account(name = "system_program", desc="The system program")]
     InitializeGame(InitializeGameArgs),
+
+    #[account(name = "player_o", signer, desc = "The player joining the game")]
+    #[account(name = "game_pda", mut, desc="The game PDA")]
     PlayerJoin,
+
     PlayerMove(PlayerMove),
 }
 

--- a/ts/idl/tictactoe.json
+++ b/ts/idl/tictactoe.json
@@ -39,7 +39,20 @@
     },
     {
       "name": "PlayerJoin",
-      "accounts": [],
+      "accounts": [
+        {
+          "name": "playerO",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "The player joining the game"
+        },
+        {
+          "name": "gamePda",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "The game PDA"
+        }
+      ],
       "args": [],
       "discriminant": {
         "type": "u8",
@@ -186,6 +199,11 @@
       "code": 7456687,
       "name": "InvalidGameAccount",
       "msg": "Game account specified is invalid."
+    },
+    {
+      "code": 7456688,
+      "name": "ShouldBeWaitingForOpponent",
+      "msg": "Game should be waiting for opponent"
     }
   ],
   "metadata": {

--- a/ts/src/generated/errors/index.ts
+++ b/ts/src/generated/errors/index.ts
@@ -101,6 +101,32 @@ createErrorFromNameLookup.set(
 )
 
 /**
+ * ShouldBeWaitingForOpponent: 'Game should be waiting for opponent'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class ShouldBeWaitingForOpponentError extends Error {
+  readonly code: number = 0x71c7b0
+  readonly name: string = 'ShouldBeWaitingForOpponent'
+  constructor() {
+    super('Game should be waiting for opponent')
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, ShouldBeWaitingForOpponentError)
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(
+  0x71c7b0,
+  () => new ShouldBeWaitingForOpponentError()
+)
+createErrorFromNameLookup.set(
+  'ShouldBeWaitingForOpponent',
+  () => new ShouldBeWaitingForOpponentError()
+)
+
+/**
  * Attempts to resolve a custom program error from the provided error code.
  * @category Errors
  * @category generated

--- a/ts/src/generated/instructions/PlayerJoin.ts
+++ b/ts/src/generated/instructions/PlayerJoin.ts
@@ -16,23 +16,49 @@ import * as web3 from '@solana/web3.js'
 export const PlayerJoinStruct = new beet.BeetArgsStruct<{
   instructionDiscriminator: number
 }>([['instructionDiscriminator', beet.u8]], 'PlayerJoinInstructionArgs')
+/**
+ * Accounts required by the _PlayerJoin_ instruction
+ *
+ * @property [**signer**] playerO The player joining the game
+ * @property [_writable_] gamePda The game PDA
+ * @category Instructions
+ * @category PlayerJoin
+ * @category generated
+ */
+export type PlayerJoinInstructionAccounts = {
+  playerO: web3.PublicKey
+  gamePda: web3.PublicKey
+}
 
 export const playerJoinInstructionDiscriminator = 1
 
 /**
  * Creates a _PlayerJoin_ instruction.
  *
+ * @param accounts that will be accessed while the instruction is processed
  * @category Instructions
  * @category PlayerJoin
  * @category generated
  */
 export function createPlayerJoinInstruction(
+  accounts: PlayerJoinInstructionAccounts,
   programId = new web3.PublicKey('Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS')
 ) {
   const [data] = PlayerJoinStruct.serialize({
     instructionDiscriminator: playerJoinInstructionDiscriminator,
   })
-  const keys: web3.AccountMeta[] = []
+  const keys: web3.AccountMeta[] = [
+    {
+      pubkey: accounts.playerO,
+      isWritable: false,
+      isSigner: true,
+    },
+    {
+      pubkey: accounts.gamePda,
+      isWritable: true,
+      isSigner: false,
+    },
+  ]
 
   const ix = new web3.TransactionInstruction({
     programId,

--- a/ts/test/tictactoe.ts
+++ b/ts/test/tictactoe.ts
@@ -2,10 +2,12 @@ import { LOCALHOST } from '@metaplex-foundation/amman-client'
 import { Connection, PublicKey, Transaction } from '@solana/web3.js'
 import {
   createInitializeGameInstruction,
+  createPlayerJoinInstruction,
   Game,
   GameState,
   InitializeGameInstructionAccounts,
   InitializeGameInstructionArgs,
+  PlayerJoinInstructionAccounts,
 } from '../src/generated'
 import { pdaForGame } from '../src/tictactoe'
 import test from 'tape'
@@ -14,32 +16,36 @@ import spok from 'spok'
 
 killStuckProcess()
 
-async function setupPlayerX() {
+async function setupPlayer(label: string) {
   // 1. Create a connection to the local test validator
   const connection = new Connection(LOCALHOST, 'confirmed')
 
   // 2. Generate a keypair for the first player and have amman label it for us
-  const [playerX, playerXPair] = await amman.addr.genLabeledKeypair('player x')
-  await amman.airdrop(connection, playerX, 2)
+  const [player, playerPair] = await amman.addr.genLabeledKeypair(label)
+  await amman.airdrop(connection, player, 2)
 
-  // 3. Create a transaction handler that will use the first player as signer
+  // 3. Create a transaction handler that will use the player as signer
   const transactionHandler = amman.payerTransactionHandler(
     connection,
-    playerXPair
+    playerPair
   )
 
   return {
-    playerXHandler: transactionHandler,
+    transactionHandler,
     connection,
-    playerX,
-    playerXPair,
+    player,
+    playerPair,
   }
 }
 
 test('tx: init game and add player x', async (t) => {
   // 1. Setup the player and its transaction handler
-  const { playerXHandler, playerX, playerXPair, connection } =
-    await setupPlayerX()
+  const {
+    transactionHandler: playerXHandler,
+    player: playerX,
+    playerPair: playerXPair,
+    connection,
+  } = await setupPlayer('player x')
 
   // 2. Generate public key for our game and derive the game PDA
   const [game] = amman.addr.genKeypair()
@@ -72,4 +78,90 @@ test('tx: init game and add player x', async (t) => {
     playerO: spokSamePubkey(PublicKey.default),
     board: spok.arrayElements(9),
   })
+})
+
+test.only('tx: join game to add player o', async (t) => {
+  // NOTE: the repetition of the init game code here. We will address that in one of the next steps.
+
+  const [game] = amman.addr.genKeypair()
+  const gamePda = await pdaForGame(game)
+  await amman.addr.addLabels({ gamePda })
+
+  // 1. setup the players
+  const {
+    transactionHandler: playerXHandler,
+    player: playerX,
+    playerPair: playerXPair,
+    connection,
+  } = await setupPlayer('player x')
+
+  const {
+    transactionHandler: playerOHandler,
+    player: playerO,
+    playerPair: playerOPair,
+  } = await setupPlayer('player o')
+
+  {
+    // 2. Initialize the game
+    const accounts: InitializeGameInstructionAccounts = {
+      playerX,
+      gamePda,
+    }
+    const args: InitializeGameInstructionArgs = {
+      initializeGameArgs: { game },
+    }
+
+    const ix = createInitializeGameInstruction(accounts, args)
+
+    const tx = new Transaction().add(ix)
+    await playerXHandler
+      .sendAndConfirmTransaction(tx, [playerXPair], 'tx: init game')
+      .assertSuccess(t, [/IX: initialize_game/])
+  }
+
+  {
+    // 3. Join the game with player o
+    const accounts: PlayerJoinInstructionAccounts = {
+      playerO,
+      gamePda,
+    }
+    const ix = createPlayerJoinInstruction(accounts)
+
+    const tx = new Transaction().add(ix)
+    await playerOHandler
+      .sendAndConfirmTransaction(tx, [playerOPair], 'tx: join game')
+      .assertSuccess(t, [/IX: player_join/])
+
+    const gameAccount = await Game.fromAccountAddress(connection, gamePda)
+    spok(t, gameAccount, {
+      $topic: 'game',
+      state: GameState.Full,
+      playerX: spokSamePubkey(playerX),
+      playerO: spokSamePubkey(playerO),
+      board: spok.arrayElements(9),
+    })
+  }
+  {
+    // 4. Try to join another player
+    const {
+      transactionHandler: playerOHandler,
+      player: playerOTwo,
+      playerPair: playerOPairTwo,
+    } = await setupPlayer('player o two')
+
+    const accounts: PlayerJoinInstructionAccounts = {
+      playerO: playerOTwo,
+      gamePda,
+    }
+    const ix = createPlayerJoinInstruction(accounts)
+
+    const tx = new Transaction().add(ix)
+    await playerOHandler
+      .sendAndConfirmTransaction(
+        tx,
+        [playerOPairTwo],
+        'fail: joining game again'
+      )
+      .assertError(t)
+  }
 })


### PR DESCRIPTION
[previous](https://github.com/thlorenz/tictactoe/pull/8) |  [next](https://github.com/thlorenz/tictactoe/pull/10)

* * *

# Summary

In this PR we added the implementation and test for the player join instruction.

## Added Functionality 

On the Rust end we updated asserts and errors to properly verify the accounts passed to the
instruction, added the required _shank_ annotations on the instruction itself in order to pass
those accounts via the SDK and updated the `player_join` processing code to update the `Game` account
accordingly.

## Updated Amman Tests

After we ran `yarn api:gen` inside the `./ts` folder we added some tests for this new
instruction.

Note that [we're using the `test.only` option here](https://github.com/thlorenz/tictactoe/pull/9/files#diff-2dea9b67cec2373f29837541da39c1f109ed5ceaee3782352d5fbd4acc103e6dR83) in order to isolate this test while we're
working on the feature. Normally we'd change this back to just `test` _before_ providing the PR, but I left it for now so you can play with it.

Also note that we're starting to repeat some code in the tests and will have to pull out some
higher level _convenience_ functions eventually. Those could then be provided to our users as a
higher level API or just serve our tests only.

### The Happy Case Test

First we added a test for the _happy_ case, a second player joining an initialized game.

When we run this via `yarn t` we see the _join_ instruction show up _after_ the _init_
instruction (the amman explorer sorts _recent transactions_ from most recent to oldest).

<img width="601" alt="Screen Shot 2022-10-20 at 9 29 52 PM" src="https://user-images.githubusercontent.com/192891/197109735-38dfb211-cafd-461b-b303-a6dde37f1fbe.png">

If we open this transaction and then the _Resolved Info_ of the `gamePda` account as we did previously, we
notice that there are now two game states.

Like the recent transactions they are sorted recent to oldest. Thus the one at the bottom is
the game state after the _init_ instruction completed and the top one shows how it was updated
as a result of the _join_ instruction.

Notice how values that changed from one state to the next are highlighted. We can click on them
to show the previous value.

We can also navigate to the _block_ that includes the transaction which caused the state
change by clicking on the slot on the upper left.

Since we're running on a local validator we have exactly two transactions in this
block. We can ignore the _Vote Program_ and instead focus in on the transaction that we
executed. As expected it is the _join game_ transaction. 

Make sure to hit _play_ in order to watch the interaction.

![join-game](https://user-images.githubusercontent.com/192891/197109772-05a81e05-1a8b-4b3e-bc0d-f339f297d599.gif)

### The Error Case Test

We also need to make sure that invalid actions are prevented. In this case we try to join
another player to a game that is already full.

In the test we name that transaction `'fail: joining game again'` to indicate that we expect it
to fail. The amman explorer will show a ❌ for transaction that were marked int this manner. 
Thus in this case we also expect the transaction label to be shown as purple.

<img width="973" alt="Screen Shot 2022-10-20 at 9 34 38 PM" src="https://user-images.githubusercontent.com/192891/197109783-17197e3c-9415-482f-8ec8-e25744aa3316.png">

Additionally [in the test we `.assertError` on the `sendConfirmTransaction` return value](https://github.com/thlorenz/tictactoe/pull/9/files#diff-2dea9b67cec2373f29837541da39c1f109ed5ceaee3782352d5fbd4acc103e6dR165) instead of asserting success.

In then next step we will improve on this to make the error assertion more specific.


In the meantime we can inspect the erronous transaction and logged messages in the explorer as usual.

<img width="964" alt="Screen Shot 2022-10-20 at 9 34 59 PM" src="https://user-images.githubusercontent.com/192891/197109805-627b7da3-e35d-4790-9864-348ac57e1b84.png">

## What you can do

Try to come up with more invalid cases, for instance initializing a game twice or joining the
same player into the game he/she initialized.

Some of those cases may not yet be caught and thus you'll need to add extra checks to the Rust
code in order to fix that.

Again make sure to run `cargo build-bpf` and `yarn api:gen` and to restart amman everytime you
change the Rust code.

* * *

[previous](https://github.com/thlorenz/tictactoe/pull/8) |  [next](https://github.com/thlorenz/tictactoe/pull/10)
