### PR TITLE
10: resolving errors with cusper

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ cd ts && yarn test
 7. [add init game functionality](https://github.com/thlorenz/tictactoe/pull/7)
 8. [amman account providers and renderers](https://github.com/thlorenz/tictactoe/pull/8)
 9. [implement join player instruction](https://github.com/thlorenz/tictactoe/pull/9)
+10. [resolving errors with cusper](https://github.com/thlorenz/tictactoe/pull/10)
 
 **NOTE**: 
 

--- a/ts/package.json
+++ b/ts/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@metaplex-foundation/beet": "^0.7.1",
     "@metaplex-foundation/beet-solana": "^0.4.0",
+    "@metaplex-foundation/cusper": "^0.0.2",
     "@solana/web3.js": "^1.66.1"
   },
   "devDependencies": {

--- a/ts/src/errors.ts
+++ b/ts/src/errors.ts
@@ -1,0 +1,4 @@
+import { initCusper } from '@metaplex-foundation/cusper'
+import { errorFromCode } from './generated'
+
+export const cusper = initCusper(errorFromCode)

--- a/ts/test/tictactoe.ts
+++ b/ts/test/tictactoe.ts
@@ -8,6 +8,7 @@ import {
   InitializeGameInstructionAccounts,
   InitializeGameInstructionArgs,
   PlayerJoinInstructionAccounts,
+  ShouldBeWaitingForOpponentError,
 } from '../src/generated'
 import { pdaForGame } from '../src/tictactoe'
 import test from 'tape'
@@ -162,6 +163,6 @@ test.only('tx: join game to add player o', async (t) => {
         [playerOPairTwo],
         'fail: joining game again'
       )
-      .assertError(t)
+      .assertError(t, ShouldBeWaitingForOpponentError)
   }
 })

--- a/ts/test/utils/amman.ts
+++ b/ts/test/utils/amman.ts
@@ -1,7 +1,9 @@
 import { Amman } from '@metaplex-foundation/amman-client'
+import { cusper } from '../../src/errors'
 
 import { PROGRAM_ADDRESS } from '../../src/tictactoe'
 
 export const amman = Amman.instance({
   knownLabels: { [PROGRAM_ADDRESS]: 'TicTacToe' },
+  errorResolver: cusper,
 })


### PR DESCRIPTION
[previous](https://github.com/thlorenz/tictactoe/pull/9) |  [next](https://github.com/thlorenz/tictactoe/pull/11)

* * *

# Summary

In this PR we install the [cusper](https://github.com/metaplex-foundation/cusper) module which
helps to resolve errors from error codes.

As we learned _solita_ generates error definitions matching the ones we define in our Rust
program. It also provides a way to resolve them via an error code. This is what cusper uses
under the hood.

## Initializing Cusper

We added a `./src/errors.ts` which provides the generated `errorFromCode` function to cusper
and exports the resulting resolver.

```ts
import { initCusper } from '@metaplex-foundation/cusper'
import { errorFromCode } from './generated'

export const cusper = initCusper(errorFromCode)
```

As you can see this provides us with an interface to resolve/throw proper `Error` objects
instead of error codes that aren't as easy to understand.

<img width="397" alt="Screen Shot 2022-10-21 at 10 34 47 AM" src="https://user-images.githubusercontent.com/192891/197251224-eb42d848-5835-45b3-aca7-ea48645ab503.png">

You can use that resolver as part of your API to make it more user friendly or in your tests
via amman as we are doing as well.

```ts
import { cusper } from '../../src/errors'
export const amman = Amman.instance({
  knownLabels: { [PROGRAM_ADDRESS]: 'TicTacToe' },
  errorResolver: cusper,
}
```

## Narrowing Errors in Tests

Once cusper is setup we can update our test that tries to add another player to a game that is
already full in order to verify that we get the exact error we expect.

```
await playerOHandler
  .sendAndConfirmTransaction(
    tx,
    [playerOPairTwo],
    'fail: joining game again'
  )
  .assertError(t, ShouldBeWaitingForOpponentError)
```

Now the test would fail if the transaction fails with a different error than `ShouldBeWaitingForOpponentError`.

## What you can do

Change the test to expect a different error, i.e. `InsufficientFundsError` and see how the
assertion now fails.

I kept the `test.only` in place so you can play with that _player join_ test in isolation.

* * *

[previous](https://github.com/thlorenz/tictactoe/pull/9) |  [next](https://github.com/thlorenz/tictactoe/pull/11)
