### PR TITLE
11: implement and test move instruction

### DIFF
--- a/program/src/accounts.rs
+++ b/program/src/accounts.rs
@@ -17,6 +17,10 @@ pub enum Player {
     PlayerO,
 }
 
+pub const BOARD_ITEM_FREE: u8 = 0;
+pub const BOARD_ITEM_X: u8 = 1;
+pub const BOARD_ITEM_O: u8 = 2;
+
 #[rustfmt::skip]
 pub const GAME_SIZE: usize = 
     /* player_x       */ 32 + 
@@ -61,5 +65,15 @@ impl Game {
             PlayerX => self.player_to_move = PlayerO,
             PlayerO => self.player_to_move = PlayerX,
         };
+    }
+
+    pub fn update_state(self: &mut Game) {
+        // TODO: add an if branch here that determines if there is a winner and
+        //       updates a property on the game account, i.e. `winner: Option<Player>`.
+        if self.board.iter().all(|&p| p != BOARD_ITEM_FREE) {
+            self.state = GameState::Finished;
+        } else {
+            self.toggle_player_to_move();
+        }
     }
 }

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -22,6 +22,12 @@ pub enum TictactoeError {
 
     #[error("Game should be waiting for opponent")]
     ShouldBeWaitingForOpponent,
+
+    #[error("Illegal move")]
+    IllegalMove,
+
+    #[error("Player attemting to move out of turn")]
+    OutOfTurnMove,
 }
 
 // -----------------

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -26,7 +26,7 @@ pub enum TictactoeError {
     #[error("Illegal move")]
     IllegalMove,
 
-    #[error("Player attemting to move out of turn")]
+    #[error("Player attempting to move out of turn")]
     OutOfTurnMove,
 }
 

--- a/program/src/instructions.rs
+++ b/program/src/instructions.rs
@@ -4,9 +4,7 @@ use solana_program::{
     account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey,
 };
 
-use crate::{
-    Game, Player, TictactoeError, BOARD_ITEM_FREE, BOARD_ITEM_O, BOARD_ITEM_X,
-};
+use crate::{Game, Player, TictactoeError, BOARD_ITEM_FREE};
 
 // -----------------
 // Instruction
@@ -41,8 +39,8 @@ pub struct InitializeGameArgs {
 // -----------------
 #[derive(BorshSerialize, BorshDeserialize, Clone, Copy)]
 pub enum MoveKind {
-    X = BOARD_ITEM_X as isize,
-    O = BOARD_ITEM_O as isize,
+    X = 1, /* BOARD_ITEM_X */
+    O = 2, /* BOARD_ITEM_O */
 }
 #[derive(BorshDeserialize)]
 pub struct PlayerMove {

--- a/program/src/instructions.rs
+++ b/program/src/instructions.rs
@@ -1,6 +1,12 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use shank::ShankInstruction;
-use solana_program::pubkey::Pubkey;
+use solana_program::{
+    account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey,
+};
+
+use crate::{
+    Game, Player, TictactoeError, BOARD_ITEM_FREE, BOARD_ITEM_O, BOARD_ITEM_X,
+};
 
 // -----------------
 // Instruction
@@ -17,6 +23,8 @@ pub enum TictactoeInstruction {
     #[account(name = "game_pda", mut, desc="The game PDA")]
     PlayerJoin,
 
+    #[account(name = "player", signer, desc = "The player making the move")]
+    #[account(name = "game_pda", mut, desc="The game PDA")]
     PlayerMove(PlayerMove),
 }
 
@@ -31,8 +39,77 @@ pub struct InitializeGameArgs {
 // -----------------
 // Player Move
 // -----------------
+#[derive(BorshSerialize, BorshDeserialize, Clone, Copy)]
+pub enum MoveKind {
+    X = BOARD_ITEM_X as isize,
+    O = BOARD_ITEM_O as isize,
+}
 #[derive(BorshDeserialize)]
 pub struct PlayerMove {
-    pub x_or_o: u8,
+    pub x_or_o: MoveKind,
     pub field: u8,
+}
+
+impl PlayerMove {
+    pub fn process(
+        &self,
+        player: &AccountInfo,
+        game: &mut Game,
+    ) -> Result<(), ProgramError> {
+        // 1. Check that the move is valid for the player
+        self.check(player, game)?;
+
+        // 2. Update the game board
+        let PlayerMove { x_or_o, field } = self;
+        game.board[*field as usize] = *x_or_o as u8;
+
+        // 3. Update the game state
+        game.update_state();
+
+        Ok(())
+    }
+
+    fn check(
+        &self,
+        player: &AccountInfo,
+        game: &Game,
+    ) -> Result<(), ProgramError> {
+        let PlayerMove { x_or_o, field } = self;
+        // Is the slot already taken?
+        if Some(&BOARD_ITEM_FREE) != game.board.get(*field as usize) {
+            return Err(TictactoeError::IllegalMove.into());
+        }
+
+        // Is the player account the correct one and is it his/her turn?
+        match x_or_o {
+            MoveKind::X => Self::check_move_player_x(player, game),
+            MoveKind::O => Self::check_move_player_o(player, game),
+        }
+    }
+
+    pub fn check_move_player_x(
+        player: &AccountInfo,
+        game: &Game,
+    ) -> Result<(), ProgramError> {
+        if player.key != &game.player_x {
+            return Err(TictactoeError::Unauthorized.into());
+        }
+        if game.player_to_move != Player::PlayerX {
+            return Err(TictactoeError::OutOfTurnMove.into());
+        }
+        Ok(())
+    }
+
+    pub fn check_move_player_o(
+        player: &AccountInfo,
+        game: &Game,
+    ) -> Result<(), ProgramError> {
+        if player.key != &game.player_o {
+            return Err(TictactoeError::Unauthorized.into());
+        }
+        if game.player_to_move != Player::PlayerO {
+            return Err(TictactoeError::OutOfTurnMove.into());
+        }
+        Ok(())
+    }
 }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -83,7 +83,7 @@ pub fn player_join(accounts: &[AccountInfo]) -> ProgramResult {
     game.player_o = *player_info.key;
     game.state = GameState::Full;
 
-    // 4 Save game state
+    // 4. Save game state
     game.serialize(&mut &mut game_pda_info.try_borrow_mut_data()?.as_mut())?;
 
     Ok(())
@@ -91,8 +91,22 @@ pub fn player_join(accounts: &[AccountInfo]) -> ProgramResult {
 
 pub fn player_move(
     accounts: &[AccountInfo],
-    _player_move: PlayerMove,
+    player_move: PlayerMove,
 ) -> ProgramResult {
     msg!("IX: player_move, passed {} accounts", accounts.len());
+
+    // 1. Extract accounts
+    let account_info_iter = &mut accounts.iter();
+    let player_info = next_account_info(account_info_iter)?;
+    let game_info = &mut next_account_info(account_info_iter)?;
+    let mut game: Game =
+        try_from_slice_unchecked(&game_info.try_borrow_data()?)?;
+
+    // 2. Use PlayerMove methods to verify and process the desired move
+    player_move.process(player_info, &mut game)?;
+
+    // 4. Save game state
+    game.serialize(&mut &mut game_info.try_borrow_mut_data()?.as_mut())?;
+
     Ok(())
 }

--- a/ts/idl/tictactoe.json
+++ b/ts/idl/tictactoe.json
@@ -61,7 +61,20 @@
     },
     {
       "name": "PlayerMove",
-      "accounts": [],
+      "accounts": [
+        {
+          "name": "player",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "The player making the move"
+        },
+        {
+          "name": "gamePda",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "The game PDA"
+        }
+      ],
       "args": [
         {
           "name": "playerMove",
@@ -135,7 +148,9 @@
         "fields": [
           {
             "name": "xOrO",
-            "type": "u8"
+            "type": {
+              "defined": "MoveKind"
+            }
           },
           {
             "name": "field",
@@ -177,6 +192,20 @@
           }
         ]
       }
+    },
+    {
+      "name": "MoveKind",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "X"
+          },
+          {
+            "name": "O"
+          }
+        ]
+      }
     }
   ],
   "errors": [
@@ -204,6 +233,16 @@
       "code": 7456688,
       "name": "ShouldBeWaitingForOpponent",
       "msg": "Game should be waiting for opponent"
+    },
+    {
+      "code": 7456689,
+      "name": "IllegalMove",
+      "msg": "Illegal move"
+    },
+    {
+      "code": 7456690,
+      "name": "OutOfTurnMove",
+      "msg": "Player attempting to move out of turn"
     }
   ],
   "metadata": {

--- a/ts/src/generated/errors/index.ts
+++ b/ts/src/generated/errors/index.ts
@@ -127,6 +127,46 @@ createErrorFromNameLookup.set(
 )
 
 /**
+ * IllegalMove: 'Illegal move'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class IllegalMoveError extends Error {
+  readonly code: number = 0x71c7b1
+  readonly name: string = 'IllegalMove'
+  constructor() {
+    super('Illegal move')
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, IllegalMoveError)
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x71c7b1, () => new IllegalMoveError())
+createErrorFromNameLookup.set('IllegalMove', () => new IllegalMoveError())
+
+/**
+ * OutOfTurnMove: 'Player attempting to move out of turn'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class OutOfTurnMoveError extends Error {
+  readonly code: number = 0x71c7b2
+  readonly name: string = 'OutOfTurnMove'
+  constructor() {
+    super('Player attempting to move out of turn')
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, OutOfTurnMoveError)
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x71c7b2, () => new OutOfTurnMoveError())
+createErrorFromNameLookup.set('OutOfTurnMove', () => new OutOfTurnMoveError())
+
+/**
  * Attempts to resolve a custom program error from the provided error code.
  * @category Errors
  * @category generated

--- a/ts/src/generated/instructions/PlayerMove.ts
+++ b/ts/src/generated/instructions/PlayerMove.ts
@@ -33,12 +33,26 @@ export const PlayerMoveStruct = new beet.BeetArgsStruct<
   ],
   'PlayerMoveInstructionArgs'
 )
+/**
+ * Accounts required by the _PlayerMove_ instruction
+ *
+ * @property [**signer**] player The player making the move
+ * @property [_writable_] gamePda The game PDA
+ * @category Instructions
+ * @category PlayerMove
+ * @category generated
+ */
+export type PlayerMoveInstructionAccounts = {
+  player: web3.PublicKey
+  gamePda: web3.PublicKey
+}
 
 export const playerMoveInstructionDiscriminator = 2
 
 /**
  * Creates a _PlayerMove_ instruction.
  *
+ * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
  *
  * @category Instructions
@@ -46,6 +60,7 @@ export const playerMoveInstructionDiscriminator = 2
  * @category generated
  */
 export function createPlayerMoveInstruction(
+  accounts: PlayerMoveInstructionAccounts,
   args: PlayerMoveInstructionArgs,
   programId = new web3.PublicKey('Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS')
 ) {
@@ -53,7 +68,18 @@ export function createPlayerMoveInstruction(
     instructionDiscriminator: playerMoveInstructionDiscriminator,
     ...args,
   })
-  const keys: web3.AccountMeta[] = []
+  const keys: web3.AccountMeta[] = [
+    {
+      pubkey: accounts.player,
+      isWritable: false,
+      isSigner: true,
+    },
+    {
+      pubkey: accounts.gamePda,
+      isWritable: true,
+      isSigner: false,
+    },
+  ]
 
   const ix = new web3.TransactionInstruction({
     programId,

--- a/ts/src/generated/types/MoveKind.ts
+++ b/ts/src/generated/types/MoveKind.ts
@@ -6,20 +6,19 @@
  */
 
 import * as beet from '@metaplex-foundation/beet'
-import { MoveKind, moveKindBeet } from './MoveKind'
-export type PlayerMove = {
-  xOrO: MoveKind
-  field: number
+/**
+ * @category enums
+ * @category generated
+ */
+export enum MoveKind {
+  X,
+  O,
 }
 
 /**
  * @category userTypes
  * @category generated
  */
-export const playerMoveBeet = new beet.BeetArgsStruct<PlayerMove>(
-  [
-    ['xOrO', moveKindBeet],
-    ['field', beet.u8],
-  ],
-  'PlayerMove'
-)
+export const moveKindBeet = beet.fixedScalarEnum(
+  MoveKind
+) as beet.FixedSizeBeet<MoveKind, MoveKind>

--- a/ts/src/generated/types/index.ts
+++ b/ts/src/generated/types/index.ts
@@ -1,4 +1,5 @@
 export * from './GameState'
 export * from './InitializeGameArgs'
+export * from './MoveKind'
 export * from './Player'
 export * from './PlayerMove'


### PR DESCRIPTION
[previous](https://github.com/thlorenz/tictactoe/pull/10)

* * *

# Summary

In this PR we added the ability for players to make TicTacToe _moves_ including tests to verify that
they are executed correctly. We also added some tests to show that _illegal_ and _out of turn_
moves are prevented.

## On the Rust End

Most of the necessary logic was added inside [`./src/instrucion.rs`](https://github.com/thlorenz/tictactoe/pull/11/files#diff-d33fe62b1d8607b6fbec981eeb6edcdd1cba4056177df2121859347a8426aefdR51) via `impl` methods on
the `PlayerMove` struct.

Mainly we check that the attempted move is valid and if it is we update the `game.board` first
and then the state of the game. Namely we toggle the player turn and update the `GameState` if
it is _finished_.

We fail however to detect a winning situation at this point as this is left to you, the workshop
attendee - see more info inside the _What Can you Do_ section below.

We added the supporting errors as well as made the `player_move` processing method call into
the above logic.

## On the SDK End

Conveniently enough we did not have to update any TypeScript code manually. That's the benefit
of using _solita_ to generate our code based on the Rust program since any changes are picked
up on re-generation.

All we had to do was run `yarn api:gen` and we were set.

Remember that on top of that we have to run `cargo build-bpf` and restart _amman_ before
running our tests that we'll update below.

## Tests In Detail

As is our common pattern by now we added [new test method inside `./test/tictactoe.ts`](https://github.com/thlorenz/tictactoe/pull/11/files#diff-2dea9b67cec2373f29837541da39c1f109ed5ceaee3782352d5fbd4acc103e6dR179) for this
added functionality.

The first test (`4.1`) adds a valid move by player x and the second (`4.2`) a valid move by player
o. If we run both of those transactions and investigate the `gamePda` in the [amman
explorer](https://amman-explorer.metaplex.com/) we can see how among other things the rendered
TicTacToe board was updated for the last two states. Remember the explorer sorts account states
most recent to oldest.

Notice in the below gif that, as with account properties, we can show the previous _rendered_
state by clicking inside the _Rendered_ area.

![move-game-01](https://user-images.githubusercontent.com/192891/197318795-abef55ef-8e52-4a4f-8eae-cbd001b74925.gif)

However we need to ensure that invalid moves are rejected by the program which we do in test
case `4.3` by attempting an _invalid_ move and in `4.4` via a _valid_, but _out of turn_ move.

In those tests we check for the particular `Error` we expect to be raised. In the amman
explorer we see both transactions as failed in _Recent Transactions_.

<img width="967" alt="Screen Shot 2022-10-21 at 7 25 20 PM" src="https://user-images.githubusercontent.com/192891/197318808-c0aa7bf3-5a4c-4623-a89c-7ba440a8174c.png">


We can inspect either one of them to learn more about how our program handled it the error, including logs.

<img width="955" alt="Screen Shot 2022-10-21 at 10 14 14 PM" src="https://user-images.githubusercontent.com/192891/197318914-7bc88316-bdee-4fcf-9474-efb08fa2e4f5.png">

Finally we can verify that the game state did not change as a result of the rejected transaction.

Note in the below screenshot that no property is highlighted which means the state did not
change during the block in which that transaction executed.

<img width="960" alt="Screen Shot 2022-10-21 at 7 26 09 PM" src="https://user-images.githubusercontent.com/192891/197318918-acdf4200-489b-4cff-9f00-9f2401322aaa.png">

## Whay You can Do

- check more invalid moves in your tests and fix any flaws you find in the Rust implemention
- update the move processing code to detect a winner and update the game state accordingly, see
  [this TODO inside `update_state` method of `./src/accounts.rs`](https://github.com/thlorenz/tictactoe/pull/11/files#diff-1413fa8928f13067522e5a8a0747347a3a1e6397d536a14421444edd866e476fR71)
- guard the contract against moves for a game that is finished due to a draw or a player
  winning
  - you may ask yourself first why it is already protected against moves in a draw situation
- verify _in the tests_ that faulty transactions don't result in game state changes
- decide if you want to provide a nice API to users of your SDK or just have utility methods in
  your tests
  - in either case try to extract the duplicate code into re-usable functions
- additionally you might want to pull out a helper function to quickly assert various
  properties of a game with spok, i.e. `runningGameToMove(player: Player)`
- ensure that all tests run again by changing the `test.only` back to `test` for the _move_
  tests

* * *

[previous](https://github.com/thlorenz/tictactoe/pull/10)